### PR TITLE
Fix driving documentation.

### DIFF
--- a/docs/get-started/drive.rst
+++ b/docs/get-started/drive.rst
@@ -69,7 +69,7 @@ Controls:
 
 * 0: ``exit``
 * a: ``increase x position 1cm``
-* a: ``decrease x position 1cm``
+* s: ``decrease x position 1cm``
 * A: ``increase x position .1cm``
 * S: ``decrease x position .1cm``
 * k: ``increase y position 1cm``


### PR DESCRIPTION
### What?
Updates the documentation to match the source code.
The key to `decrease x position 1cm` is `s`, not `a`.

**See:** https://github.com/evildmp/BrachioGraph/blob/5eae2b5bd0e4c701818f25bb0441670b2986e28c/brachiograph.py#L471:L472