### PR TITLE
giving svg output height and width parameters

### DIFF
--- a/linedraw.py
+++ b/linedraw.py
@@ -332,7 +332,10 @@ def hatch(IM,sc=16):
 
 def makesvg(lines):
     print("generating svg file...")
-    out = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1">'
+    width = math.ceil(max([max([p[0]*0.5 for p in l]) for l in lines]))
+    height = math.ceil(max([max([p[1]*0.5 for p in l]) for l in lines]))
+    out = '<svg xmlns="http://www.w3.org/2000/svg" height="%spx" width="%spx" version="1.1">' % (height, width)
+
     for l in lines:
         l = ",".join([str(p[0]*0.5)+","+str(p[1]*0.5) for p in l])
         out += '<polyline points="'+l+'" stroke="black" stroke-width="2" fill="none" />\n'


### PR DESCRIPTION
when I was opening with feh and gimp, they were having issues due to not having these element options. A much faster method could be more hardcoded by just dividing the original images resolution by two, but I felt this code was more independent.