### PR TITLE
Undefined name: bounds --> self.bounds

### DIFF
--- a/brachiograph.py
+++ b/brachiograph.py
@@ -310,7 +310,7 @@ class BrachioGraph:
 
     def centre(self):
 
-        if not bounds:
+        if not self.bounds:
             return "Moving to the centre is only possible when BrachioGraph.bounds is set."
 
 


### PR DESCRIPTION
__bounds__ is an _undefined name_ in this context which has the potential to raise NameError at runtime so this PR suggests using __self.bounds__ instead.

[flake8](http://flake8.pycqa.org) testing of https://github.com/evildmp/BrachioGraph on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./brachiograph.py:313:16: F821 undefined name 'bounds'
        if not bounds:
               ^
1     F821 undefined name 'bounds'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree