### PR TITLE
requirements.txt: Remove redundant entries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-pigpio
-tqdm
-readchar
 numpy
-tqdm
+pigpio
 readchar
+tqdm


### PR DESCRIPTION
Best practice is to keep dependencies in alphabetical order so duplicates are easily spotted.