### PR TITLE
Correct pins in use in wiring documentation

### DIFF
--- a/docs/get-started/wiring.rst
+++ b/docs/get-started/wiring.rst
@@ -18,7 +18,7 @@ We connect:
 * elbow motor: GPIO pin 15
 * lifting motor: GPIO pin 18
 
-These correspond to pins 2-12 on the Pi's header. See https://pinout.xyz.
+These correspond to pins 4-12 on the Pi's header. See https://pinout.xyz.
 
 .. image:: /images/pin-connections.jpg
    :alt: 'Pin connections'


### PR DESCRIPTION
Pins 2 and 4 are +5V, we only use pin 4