### PR TITLE
Fix incorrect (?) flip=True within plot_file() and plot_lines()

### DIFF
--- a/brachiograph.py
+++ b/brachiograph.py
@@ -161,7 +161,7 @@ class BrachioGraph:
         with open(filename, "r") as line_file:
             lines = json.load(line_file)
 
-        self.plot_lines(lines=lines, wait=wait, interpolate=interpolate, bounds=bounds, flip=True)
+        self.plot_lines(lines=lines, wait=wait, interpolate=interpolate, bounds=bounds)
 
 
     def plot_lines(self, lines=[], wait=0, interpolate=10, rotate=False, flip=False, bounds=None):
@@ -172,7 +172,7 @@ class BrachioGraph:
         if not bounds:
             return "Line plotting is only possible when BrachioGraph.bounds is set."
 
-        lines = self.rotate_and_scale_lines(lines=lines, bounds=bounds, flip=True)
+        lines = self.rotate_and_scale_lines(lines=lines, bounds=bounds, flip=flip)
 
         for line in tqdm.tqdm(lines, desc="Lines", leave=False):
             x, y = line[0]


### PR DESCRIPTION
When

1. plotting a file via `plot_file()` or
2. a set of lines via `plot_lines()`,

my drawings come out flipped along the *x*-axis. Taking a look at the code, I noticed that

1. `plot_file()` calls `plot_lines()` with `flip=True`, which seems wrong but the removal of which didn't fix my problems on its own, and
2. `plot_lines()` calls `rotate_and_scale_lines()` with `flip=True`. Instead supplying `flip=flip`, in conjunction with the previous point, fixes both of my problems.

According to `git blame`, these two occurrences of `flip=True` have been present for quite a while. Given this and the lack of issues or pull requests relating to the problems I encountered, I'm not sure if this is actually *wrong* or if something on my side is set up incorrectly.