### PR TITLE
Fix for drawing out of bounds

### DIFF
--- a/brachiograph.py
+++ b/brachiograph.py
@@ -230,10 +230,13 @@ class BrachioGraph:
                 x = point[0]
                 x = x - x_mid_point         # shift x values so that they have zero as their mid-point
                 x = x / divider             # scale x values to fit in our box width
+
+
+                if flip ^ rotate:           # flip before moving back into drwaing pane
+                    x = -x
+
                 x = x + box_x_mid_point     # shift x values so that they have the box x midpoint as their endpoint
 
-                if flip ^ rotate:
-                    x = -x
 
                 y = point[1]
                 y = y - y_mid_point


### PR DESCRIPTION
I discovered incorrect behavior regarding the flip behavior in the function `rotate and scale lines()` within the class `Brachio-
Graph` in `brachiograph.py`.

The expression `
```
if flip ˆrotate: x = -x`
```
should precede the statement 
```
x = x + box x mid point
```

In the current master the flip statement is after the addition. This (incorrect) sequence causes the inversion to not happen around the center of gravity of the box but after the shift away from this center resulting in an x offset that brings the coordinates out of the drawing bounds.
