### PR TITLE
Small fix in BrachioGraph init

### DIFF
--- a/brachiograph.py
+++ b/brachiograph.py
@@ -55,7 +55,7 @@ class BrachioGraph(Plotter):
         super().__init__(
             bounds=bounds,
             servo_1_parked_pw=servo_1_parked_pw,
-            servo_2_parked_pw=servo_1_parked_pw,
+            servo_2_parked_pw=servo_2_parked_pw,
             servo_1_degree_ms=servo_1_degree_ms,
             servo_2_degree_ms=servo_2_degree_ms,
             servo_1_parked_angle=servo_1_parked_angle,


### PR DESCRIPTION
Fixed the typo in the init code where `servo_2_parked_pw` was set from `servo_1_parked_pw` variable.
Before the fix both `servo_1_parked_pw` and `servo_2_parked_pw` were initialized from `servo_1_parked_pw` variable.