### PR TITLE
Fixed small documentation error in linedraw.rst

### DIFF
--- a/docs/reference/linedraw.rst
+++ b/docs/reference/linedraw.rst
@@ -14,7 +14,7 @@
         draw_contours=False,  # suggested value: 2
         repeat_contours=1,    # increase to draw the contours multiple times
         draw_hatch=False,     # suggested value: 16
-        repeat_contours=1,    # increase to draw the hatching multiple times
+        repeat_hatch=1,    # increase to draw the hatching multiple times
         ):
 
 * ``image_filename``:  all images are expected to be found in the ``images`` directory


### PR DESCRIPTION
"repeat_contours" was repeated, instead of using "repeat_hatch" to specify drawing the hatch multiple times